### PR TITLE
add "Proxy-Authenticate" header for http2

### DIFF
--- a/http.go
+++ b/http.go
@@ -211,6 +211,7 @@ func (s *Http2Server) HandleRequest(w http.ResponseWriter, req *http.Request) {
 	}
 	if len(s.Base.Node.Users) > 0 && !valid {
 		glog.V(LWARNING).Infof("[http2] %s <- %s : proxy authentication required", req.RemoteAddr, target)
+		w.Header().Set("Proxy-Authenticate", "Basic realm=\"gost\"")
 		w.WriteHeader(http.StatusProxyAuthRequired)
 		return
 	}


### PR DESCRIPTION
Without "Proxy-Authenticate" header, Proxy Authentication of http2 will not work correctly on chrome(With SwitchyOmega). Vendor should also be update soon.
