### PR TITLE
Build gost after go1.8.3, so go 1.8.3 can be used in the build.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,11 +1,11 @@
-name: gost # you probably want to 'snapcraft register <name>'
-version: '2.4' # just for humans, typically '1.2+git' or '1.3.2'
+name: gost
+version: '2.4'
 summary: GO Simple Tunnel
 description: |
   A simple tunnel written in golang
 
 grade: stable
-confinement: strict # use 'strict' once you have the right plugs and slots
+confinement: strict
 
 apps:
   gost:
@@ -15,9 +15,8 @@ apps:
 parts:
   gost:
     source: .
-    # See 'snapcraft plugins'
     plugin: go
-    go-packages: [github.com/ginuerzh/gost/cmd/gost]
     go-importpath: github.com/ginuerzh/gost
+    after: [go]
   go:
     source-tag: go1.8.3


### PR DESCRIPTION
The snap was failing to build because it was using older version of go to build gost. This change makes sure that `go1.8.3` is built before `gost`, so it gets used in the build of gost.

The snap will still fail, but that seems to be a problem on master:
```
go build -o /home/ev/gost/parts/gost/go/bin/gost github.com/ginuerzh/gost/cmd/gost
go build -o /home/ev/gost/parts/gost/go/bin/bench github.com/ginuerzh/gost/examples/bench
# github.com/ginuerzh/gost/examples/bench
github.com/ginuerzh/gost/examples/bench/srv.go:17: quiet redeclared in this block
	previous declaration at github.com/ginuerzh/gost/examples/bench/cli.go:19
github.com/ginuerzh/gost/examples/bench/srv.go:33: main redeclared in this block
	previous declaration at github.com/ginuerzh/gost/examples/bench/cli.go:38
```

Pinning to the most recent release tag of gost fixes the snap:
```
parts:
  gost:
    source: .
    source-type: git
    source-tag: 'v2.3'
    plugin: go
    go-importpath: github.com/ginuerzh/gost
    after: [go]
```