### PR TITLE
fix panic error

### DIFF
--- a/sni.go
+++ b/sni.go
@@ -59,12 +59,12 @@ func (h *sniHandler) Handle(conn net.Conn) {
 	if hdr[0] != dissector.Handshake {
 		// We assume it is an HTTP request
 		req, err := http.ReadRequest(bufio.NewReader(conn))
-		if !req.URL.IsAbs() {
-			req.URL.Scheme = "http" // make sure that the URL is absolute
-		}
 		if err != nil {
 			log.Logf("[sni] %s - %s : %s", conn.RemoteAddr(), conn.LocalAddr(), err)
 			return
+		}
+		if !req.URL.IsAbs() {
+			req.URL.Scheme = "http" // make sure that the URL is absolute
 		}
 		HTTPHandler(h.options...).(*httpHandler).handleRequest(conn, req)
 		return


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x7c0555]

goroutine 84 [running]:
github.com/ginuerzh/gost.(*sniHandler).Handle(0xc42028d520, 0xb05340, 0xc42000e468)
	/root/gopath/src/github.com/ginuerzh/gost/sni.go:65 +0x445
created by github.com/ginuerzh/gost.(*Server).Serve
	/root/gopath/src/github.com/ginuerzh/gost/server.go:62 +0x145
exit status 2
```