### PR TITLE
Fix http Handle

### DIFF
--- a/http.go
+++ b/http.go
@@ -92,6 +92,7 @@ func (h *httpHandler) Handle(conn net.Conn) {
 		log.Logf("[http] %s - %s : %s", conn.RemoteAddr(), conn.LocalAddr(), err)
 		return
 	}
+	defer req.Body.Close()
 
 	h.handleRequest(conn, req)
 }


### PR DESCRIPTION
need req.Body.Close() to avoid memory leaks