### PR TITLE
fix build in go-1.10.3 at win

### DIFF
--- a/redirect_win.go
+++ b/redirect_win.go
@@ -25,6 +25,10 @@ func TCPRedirectHandler(opts ...HandlerOption) Handler {
 	return h
 }
 
+func (h *tcpRedirectHandler) Init(options ...HandlerOption) {
+	log.Log("[red-tcp] TCP redirect is not available on the Windows platform")
+}
+
 func (h *tcpRedirectHandler) Handle(c net.Conn) {
 	log.Log("[red-tcp] TCP redirect is not available on the Windows platform")
 	c.Close()


### PR DESCRIPTION
Fix Error:
```
# github.com/ginuerzh/gost
.\redirect_win.go:25:2: cannot use h (type *tcpRedirectHandler) as type Handler in return argument:
        *tcpRedirectHandler does not implement Handler (missing Init method)
```