### PR TITLE
Fix: ss: block if server send first(like mysql)

### DIFF
--- a/ss.go
+++ b/ss.go
@@ -64,9 +64,8 @@ func (c *shadowConnector) Connect(conn net.Conn, addr string, options ...Connect
 	sc := &shadowConn{
 		Conn: ss.NewConn(conn, cipher),
 	}
-	sc.wbuf.Write(rawaddr) // cache the header
-
-	return sc, nil
+	_, err = sc.Write(rawaddr)
+	return sc, err
 }
 
 type shadowHandler struct {


### PR DESCRIPTION
If client connect without send any data(maybe wait for server,like mysql), it will not  create connection
cause is that cache.