### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME=gost
 BINDIR=bin
 VERSION=$(shell cat gost.go | grep 'Version =' | sed 's/.*\"\(.*\)\".*/\1/g')
-GOBUILD=CGO_ENABLED=0 go build
+GOBUILD=CGO_ENABLED=0 go build --ldflags="-s -w" -v -x -a
 GOFILES=cmd/gost/*
 
 PLATFORM_LIST = \


### PR DESCRIPTION
1. Statically linked and reduce size
2. Make it more verbose
3. Force rebuild packages if already up-to-date