### PR TITLE
Build go binaries without QEMU

### DIFF
--- a/.github/workflows/buildx.yaml
+++ b/.github/workflows/buildx.yaml
@@ -47,14 +47,14 @@ jobs:
 
     - name: Docker Buildx (no push)
       run: |
-        docker buildx build \
-          --platform ${{ steps.prepare.outputs.docker_platforms }} \
-          --output "type=image,push=false" \
-          --build-arg "VERSION=${{ steps.prepare.outputs.version }}" \
-          --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
-          --build-arg "VCS_REF=${GITHUB_SHA::8}" \
-          --tag "${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}" \
-          --file Dockerfile .
+        docker buildx bake \
+          --set ${{ github.event.repository.name }}.platform=${{ steps.prepare.outputs.docker_platforms }} \
+          --set ${{ github.event.repository.name }}.output=type=image,push=false \
+          --set ${{ github.event.repository.name }}.args.VERSION=${{ steps.prepare.outputs.version }} \
+          --set ${{ github.event.repository.name }}.args.BUILD_DATE=${{ steps.prepare.outputs.build_date }} \
+          --set ${{ github.event.repository.name }}.args.VCS_REF=${GITHUB_SHA::8} \
+          --set ${{ github.event.repository.name }}.tags="${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}" \
+          --file docker-compose.yaml
 
     - name: Docker Login
       if: success()
@@ -66,14 +66,14 @@ jobs:
     - name: Docker Buildx (push)
       if: success()
       run: |
-        docker buildx build \
-          --platform ${{ steps.prepare.outputs.docker_platforms }} \
-          --output "type=image,push=true" \
-          --build-arg "VERSION=${{ steps.prepare.outputs.version }}" \
-          --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
-          --build-arg "VCS_REF=${GITHUB_SHA::8}" \
-          --tag "${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}" \
-          --file Dockerfile .
+        docker buildx bake \
+          --set ${{ github.event.repository.name }}.platform=${{ steps.prepare.outputs.docker_platforms }} \
+          --set ${{ github.event.repository.name }}.output=type=image,push=true \
+          --set ${{ github.event.repository.name }}.args.VERSION=${{ steps.prepare.outputs.version }} \
+          --set ${{ github.event.repository.name }}.args.BUILD_DATE=${{ steps.prepare.outputs.build_date }} \
+          --set ${{ github.event.repository.name }}.args.VCS_REF=${GITHUB_SHA::8} \
+          --set ${{ github.event.repository.name }}.tags="${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}" \
+          --file docker-compose.yaml
 
     - name: Clear
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM golang:1-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1-alpine as builder
+
+# Convert TARGETPLATFORM to GOARCH format
+# https://github.com/tonistiigi/xx
+COPY --from=tonistiigi/xx:golang / /
+
+ARG TARGETPLATFORM
 
 RUN apk add --no-cache musl-dev git gcc
 
@@ -8,7 +14,7 @@ WORKDIR /src
 
 ENV GO111MODULE=on
 
-RUN cd cmd/gost && go build
+RUN cd cmd/gost && go env && go build -v
 
 FROM alpine:latest
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,4 @@
+version: "3.4"
+services:
+  gost:
+    build: .


### PR DESCRIPTION
Go already can cross-build easily for other architectures, so using QEMU is quite a bit slower.

Here I've changed the Dockerfile to use the --platform arg for FROM and tell Go what ARCH to build for.

I've also switched the build to use `buildx bake` which will run all the builds in parallel.  Bake doesn't work directly with a Dockerfile, so I created a quick docker-compose.yaml file for it to use.

This builds all the images in about 2 minutes.

Also, there seems to be a bug with calling '${GITHUB_SHA::8}'  maybe you want to remove the ::8 but I didn't want to change it, not sure what it was there for.