### PR TITLE
Certificate pinning for websocket

### DIFF
--- a/ws.go
+++ b/ws.go
@@ -788,12 +788,13 @@ func websocketClientConn(url string, conn net.Conn, tlsConfig *tls.Config, optio
 	if err != nil {
 		return nil, err
 	}
+	resp.Body.Close()
+
 	if verifyErr != nil {
 		c.Close()
 		return nil, verifyErr
 	}
 
-	resp.Body.Close()
 	return &websocketConn{conn: c}, nil
 }
 

--- a/ws.go
+++ b/ws.go
@@ -789,6 +789,7 @@ func websocketClientConn(url string, conn net.Conn, tlsConfig *tls.Config, optio
 		return nil, err
 	}
 	if verifyErr != nil {
+		c.Close()
 		return nil, verifyErr
 	}
 


### PR DESCRIPTION
fix #629 

Certificate pinning is only valid in TLS, this patch adds support for websocket.