### PR TITLE
Add installation instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ go build
 docker pull ginuerzh/gost
 ```
 
+#### Homebrew
+
+```bash
+brew install gost
+```
+
 #### Ubuntu商店
 
 ```bash

--- a/README_en.md
+++ b/README_en.md
@@ -57,6 +57,12 @@ go build
 docker pull ginuerzh/gost
 ```
 
+#### Homebrew
+
+```bash
+brew install gost
+```
+
 #### Ubuntu store
 
 ```bash


### PR DESCRIPTION
Hi, @ginuerzh! I add a [pull request](https://github.com/Homebrew/homebrew-core/pull/62915) for `gost` to homebrew-core, and it has been accepted by the homebrew maintainers.

From now on, we can install `gost` on macOS with homebrew, or even on Linux with linuxbrew (maybe there is some delay).

```console
brew install gost
```