### PR TITLE
add support for loading peerConfig from a url

### DIFF
--- a/cmd/gost/peer.go
+++ b/cmd/gost/peer.go
@@ -14,14 +14,14 @@ import (
 )
 
 type peerConfig struct {
-	Strategy    string `json:"strategy"`
-	MaxFails    int    `json:"max_fails"`
-	FailTimeout time.Duration
-	period      time.Duration // the period for live reloading
-	Nodes       []string      `json:"nodes"`
-	group       *gost.NodeGroup
-	baseNodes   []gost.Node
-	stopped     chan struct{}
+	Strategy     string        `json:"strategy"`
+	MaxFails     int           `json:"max_fails"`
+	FailTimeout  time.Duration `json:"fail_timeout"`
+	ReloadPeriod time.Duration `json:"reload"`
+	Nodes        []string      `json:"nodes"`
+	group        *gost.NodeGroup
+	baseNodes    []gost.Node
+	stopped      chan struct{}
 }
 
 func newPeerConfig() *peerConfig {
@@ -129,7 +129,7 @@ func (cfg *peerConfig) parse(r io.Reader) error {
 		case "fail_timeout":
 			cfg.FailTimeout, _ = time.ParseDuration(ss[1])
 		case "reload":
-			cfg.period, _ = time.ParseDuration(ss[1])
+			cfg.ReloadPeriod, _ = time.ParseDuration(ss[1])
 		case "peer":
 			cfg.Nodes = append(cfg.Nodes, ss[1])
 		}
@@ -142,7 +142,7 @@ func (cfg *peerConfig) Period() time.Duration {
 	if cfg.Stopped() {
 		return -1
 	}
-	return cfg.period
+	return cfg.ReloadPeriod
 }
 
 // Stop stops reloading.

--- a/reload.go
+++ b/reload.go
@@ -1,7 +1,9 @@
 package gost
 
 import (
+	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"time"
 
@@ -55,6 +57,42 @@ func PeriodReload(r Reloader, configFile string) error {
 		period := r.Period()
 		if period == 0 {
 			log.Log("[reload] disabled:", configFile)
+			return nil
+		}
+		if period < time.Second {
+			period = time.Second
+		}
+		<-time.After(period)
+	}
+}
+
+// PeriodReloadRemote reloads the remote configFile periodically according to the period of the Reloader r.
+func PeriodReloadRemote(r Reloader, cfg string) error {
+	if r == nil || cfg == "" {
+		return nil
+	}
+
+	for {
+		if r.Period() < 0 {
+			log.Log("[reload] stopped:", cfg)
+			return nil
+		}
+		client := http.Client{}
+		resp, err := client.Get(cfg)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			return fmt.Errorf("fetch remote resource error, reply status code is not equals to 200")
+		}
+		if err := r.Reload(resp.Body); err != nil {
+			log.Logf("[reload] %s: %s", cfg, err)
+		}
+
+		period := r.Period()
+		if period == 0 {
+			log.Log("[reload] disabled:", cfg)
 			return nil
 		}
 		if period < time.Second {


### PR DESCRIPTION
支持使用url作为peer参数，这样更方便做到代理节点的动态加载。
从url加载的peerConfig可以是json格式，例如：
{"strategy":"fifo","max_fails":1,"fail_timeout":14000000000,"reload":30000000000,"nodes":["http://admin:admin@213.76.3.22:7788"]}