### PR TITLE
add support for loading peerConfig from an url

### DIFF
--- a/cmd/gost/peer.go
+++ b/cmd/gost/peer.go
@@ -14,14 +14,14 @@ import (
 )
 
 type peerConfig struct {
-	Strategy    string `json:"strategy"`
-	MaxFails    int    `json:"max_fails"`
-	FailTimeout time.Duration
-	period      time.Duration // the period for live reloading
-	Nodes       []string      `json:"nodes"`
-	group       *gost.NodeGroup
-	baseNodes   []gost.Node
-	stopped     chan struct{}
+	Strategy     string        `json:"strategy"`
+	MaxFails     int           `json:"max_fails"`
+	FailTimeout  time.Duration `json:"fail_timeout"`
+	ReloadPeriod time.Duration `json:"reload"`
+	Nodes        []string      `json:"nodes"`
+	group        *gost.NodeGroup
+	baseNodes    []gost.Node
+	stopped      chan struct{}
 }
 
 func newPeerConfig() *peerConfig {
@@ -129,7 +129,7 @@ func (cfg *peerConfig) parse(r io.Reader) error {
 		case "fail_timeout":
 			cfg.FailTimeout, _ = time.ParseDuration(ss[1])
 		case "reload":
-			cfg.period, _ = time.ParseDuration(ss[1])
+			cfg.ReloadPeriod, _ = time.ParseDuration(ss[1])
 		case "peer":
 			cfg.Nodes = append(cfg.Nodes, ss[1])
 		}
@@ -142,7 +142,7 @@ func (cfg *peerConfig) Period() time.Duration {
 	if cfg.Stopped() {
 		return -1
 	}
-	return cfg.period
+	return cfg.ReloadPeriod
 }
 
 // Stop stops reloading.


### PR DESCRIPTION
支持使用url作为peer参数，这样更方便做到代理节点的动态加载。
从url加载的peerConfig可以是json格式，例如：
`{"strategy":"fifo","max_fails":1,"fail_timeout":14000000000,"reload":30000000000,"nodes":["http://admin:admin@213.76.3.22:7788"]}`