### PR TITLE
bump github.com/milosgajdos/tenus to v0.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/lucas-clemente/quic-go v0.10.0
 	github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced // indirect
 	github.com/miekg/dns v1.1.35
-	github.com/milosgajdos83/tenus v0.0.0-20190415114537-1f3ed00ae7d8
+	github.com/milosgajdos/tenus v0.0.3
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/shadowsocks/go-shadowsocks2 v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cce
 github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced/go.mod h1:NCcRLrOTZbzhZvixZLlERbJtDtYsmMw8Jc4vS8Z0g58=
 github.com/miekg/dns v1.1.35 h1:oTfOaDH+mZkdcgdIjH6yBajRGtIwcwcaR+rt23ZSrJs=
 github.com/miekg/dns v1.1.35/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
+github.com/milosgajdos/tenus v0.0.3 h1:jmaJzwaY1DUyYVD0lM4U+uvP2kkEg1VahDqRFxIkVBE=
+github.com/milosgajdos/tenus v0.0.3/go.mod h1:eIjx29vNeDOYWJuCnaHY2r4fq5egetV26ry3on7p8qY=
 github.com/milosgajdos83/tenus v0.0.0-20190415114537-1f3ed00ae7d8 h1:4WFQEfEJ7zaHYViIVM2Cd6tnQOOhiEHbmQtlcV7aOpc=
 github.com/milosgajdos83/tenus v0.0.0-20190415114537-1f3ed00ae7d8/go.mod h1:G95Wwn625/q6JCCytI4VR/a5VtPwrtI0B+Q1Gi38QLA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/tuntap_linux.go
+++ b/tuntap_linux.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/docker/libcontainer/netlink"
 	"github.com/go-log/log"
-	"github.com/milosgajdos83/tenus"
+	"github.com/milosgajdos/tenus"
 	"github.com/songgao/water"
 )
 


### PR DESCRIPTION
依赖的包名从 github.com/milosgajdos83/tenus 变成了 github.com/milosgajdos/tenus
另外 v0.0.3 包含了一处修复 https://github.com/milosgajdos/tenus/commit/4c07e9afd868e8a810d552ddba9ae4516ca64b9a
可以防止其他依赖 github.com/ginuerzh/gost 的包用 bazel 构建时的报错