### PR TITLE
Spawn multiple gost instances in a single command with --

### DIFF
--- a/cmd/gost/cfg.go
+++ b/cmd/gost/cfg.go
@@ -25,18 +25,18 @@ type baseConfig struct {
 	Debug  bool
 }
 
-func parseBaseConfig(s string) (*baseConfig, error) {
+func parseBaseConfig(s string, baseCfg *baseConfig) error {
 	file, err := os.Open(s)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer file.Close()
 
 	if err := json.NewDecoder(file).Decode(baseCfg); err != nil {
-		return nil, err
+		return err
 	}
 
-	return baseCfg, nil
+	return nil
 }
 
 var (

--- a/cmd/gost/main.go
+++ b/cmd/gost/main.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
+	"strings"
 	"runtime"
 
 	_ "net/http/pprof"
@@ -16,56 +18,148 @@ import (
 )
 
 var (
-	configureFile string
-	baseCfg       = &baseConfig{}
-	pprofAddr     string
 	pprofEnabled  = os.Getenv("PROFILING") != ""
 )
 
 func init() {
 	gost.SetLogger(&gost.LogLogger{})
 
-	var (
-		printVersion bool
-	)
-
-	flag.Var(&baseCfg.route.ChainNodes, "F", "forward address, can make a forward chain")
-	flag.Var(&baseCfg.route.ServeNodes, "L", "listen address, can listen on multiple ports (required)")
-	flag.StringVar(&configureFile, "C", "", "configure file")
-	flag.BoolVar(&baseCfg.Debug, "D", false, "enable debug log")
-	flag.BoolVar(&printVersion, "V", false, "print version")
-	if pprofEnabled {
-		flag.StringVar(&pprofAddr, "P", ":6060", "profiling HTTP server address")
-	}
-	flag.Parse()
-
-	if printVersion {
-		fmt.Fprintf(os.Stdout, "gost %s (%s %s/%s)\n",
-			gost.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
-		os.Exit(0)
-	}
-
-	if configureFile != "" {
-		_, err := parseBaseConfig(configureFile)
-		if err != nil {
-			log.Log(err)
-			os.Exit(1)
-		}
-	}
-	if flag.NFlag() == 0 {
-		flag.PrintDefaults()
-		os.Exit(0)
-	}
+	// TODO - Generate different certificates for each worker
+	generateTLSCertificate()
 }
 
 func main() {
-	if pprofEnabled {
-		go func() {
-			log.Log("profiling server on", pprofAddr)
-			log.Log(http.ListenAndServe(pprofAddr, nil))
-		}()
+	var wg sync.WaitGroup
+	wg.Add(1)  // Gost must exit if any of the workers exit
+
+	// Split os.Args using -- and create a worker with each slice
+	args := strings.Split(" " + strings.Join(os.Args[1:], "  ") + " ", " -- ")
+	if strings.Join(args, "") == "" {
+		// Fix to show gost help if the resulting array is empty
+		args[0] = " "
+	}
+	for wid, wargs := range args {
+		if wargs != "" {
+			go worker(wid, wargs, &wg)
+		}
+	}
+	wg.Wait()
+}
+
+func worker(id int, args string, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	var (
+		configureFile string
+		baseCfg       = &baseConfig{}
+		pprofAddr     string
+	)
+
+	init := func () error {
+		var printVersion bool
+
+		wf := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+		wf.Var(&baseCfg.route.ChainNodes, "F", "forward address, can make a forward chain")
+		wf.Var(&baseCfg.route.ServeNodes, "L", "listen address, can listen on multiple ports (required)")
+		wf.StringVar(&configureFile, "C", "", "configure file")
+		wf.BoolVar(&baseCfg.Debug, "D", false, "enable debug log")
+		wf.BoolVar(&printVersion, "V", false, "print version")
+
+		if pprofEnabled {
+			// Every worker uses a different profiling server by default
+			wf.StringVar(&pprofAddr, "P", fmt.Sprintf(":606%d", id), "profiling HTTP server address")
+		}
+
+		wf.Parse(strings.Fields(args))
+
+		if printVersion {
+			fmt.Fprintf(os.Stdout, "gost %s (%s %s/%s)\n", gost.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+			os.Exit(0)
+		} else if wf.NFlag() == 0 {
+			wf.Usage()
+			os.Exit(0)
+		} else if configureFile != "" {
+			err := parseBaseConfig(configureFile, baseCfg)
+			if err != nil {
+				return err
+			}
+		}
+
+		if baseCfg.route.ServeNodes.String() == "[]" {
+			configErrMsg := ""
+			if configureFile != "" {
+				configErrMsg = " or ServeNodes inside config file (-C)"
+			}
+			fmt.Fprintf(os.Stderr, "\n[!] Error: Missing -L flag%s\n\n", configErrMsg)
+			wf.Usage()
+			os.Exit(1)
+		}
+
+		return nil
 	}
 
+	start := func () error {
+		// TODO - Make debug worker independent
+		if ! gost.Debug {
+			gost.Debug = baseCfg.Debug
+		}
+
+		var routers []router
+		rts, err := baseCfg.route.GenRouters()
+		if err != nil {
+			return err
+		}
+		routers = append(routers, rts...)
+
+		for _, route := range baseCfg.Routes {
+			rts, err := route.GenRouters()
+			if err != nil {
+				return err
+			}
+			routers = append(routers, rts...)
+		}
+
+		if len(routers) == 0 {
+			return errors.New("invalid config")
+		}
+		for i := range routers {
+			go routers[i].Serve()
+		}
+
+		return nil
+	}
+
+	main := func () error {
+		if pprofEnabled {
+			go func() {
+				log.Log("profiling server on", pprofAddr)
+				log.Log(http.ListenAndServe(pprofAddr, nil))
+			}()
+		}
+
+		err := start()
+		return err
+	}
+
+	if err := init(); err != nil {
+		log.Log(err)
+		return
+	}
+	if err := main(); err != nil {
+		log.Log(err)
+		return
+	}
+
+	// Allow local functions to be garbage-collected
+	init = nil
+	main = nil
+	start = nil
+
+	select {}
+}
+
+func generateTLSCertificate() {
 	// NOTE: as of 2.6, you can use custom cert/key files to initialize the default certificate.
 	tlsConfig, err := tlsConfig(defaultCertFile, defaultKeyFile, "")
 	if err != nil {
@@ -81,41 +175,5 @@ func main() {
 	} else {
 		log.Log("load TLS certificate files OK")
 	}
-
 	gost.DefaultTLSConfig = tlsConfig
-
-	if err := start(); err != nil {
-		log.Log(err)
-		os.Exit(1)
-	}
-
-	select {}
-}
-
-func start() error {
-	gost.Debug = baseCfg.Debug
-
-	var routers []router
-	rts, err := baseCfg.route.GenRouters()
-	if err != nil {
-		return err
-	}
-	routers = append(routers, rts...)
-
-	for _, route := range baseCfg.Routes {
-		rts, err := route.GenRouters()
-		if err != nil {
-			return err
-		}
-		routers = append(routers, rts...)
-	}
-
-	if len(routers) == 0 {
-		return errors.New("invalid config")
-	}
-	for i := range routers {
-		go routers[i].Serve()
-	}
-
-	return nil
 }


### PR DESCRIPTION
Hi,

Congratulations for this amazing tool 💯! It is my go-to whenever I need to create tunnels 🎉

Due to the fact I use socks over reverse-tunnels a lot, this PR allows a single gost command to perform multiple operations in separated instances.

This is easier to explain with a short example:

**Before** this PR this is what you had to do if you wanted to create a socks over reverse-SSH:
```sh
# Server
gost -L forward+ssh://:2222

# Client - Terminal/Process 1
gost -L rtcp://127.0.0.1:3333/127.0.0.1:1111 -F forward+ssh://<server-ip>:2222

# Client - Terminal/Process 2
gost -L socks5://127.0.0.1:1111

# Test from Server
curl -s -L -x socks5://127.0.0.1:3333 https://example.com
```

**After** this PR the client no longer needs to use multiple terminals/processes:
```sh
# Server
gost -L forward+ssh://:2222

# Client
gost -L socks5://127.0.0.1:1111 -- -L rtcp://127.0.0.1:3333/127.0.0.1:1111 -F forward+ssh://<server-ip>:2222

# Test from Server
curl -s -L -x socks5://127.0.0.1:3333 https://example.com
```

This works by spawning a different gost instance in a goroutine with each `--`, so there are no configuration conflicts ✨!

You can certainly use multiple `--` to do all sort of craziness in a single gost command:
```sh
gost -L rudp://:5353/192.168.1.1:53?ttl=60s -F socks5://172.24.10.1:1080    -- \
     -C my-proxy.json                                                       -- \
     -L redirect://:1234 -F 1.2.3.4:1080                                    -- \
     -L udp://:5353 -C forward-servers.json                                 -- \
     -L :8080 -F http://localhost:8080?ip=192.168.1.2:8081,192.168.1.3:8082    \
              -F socks5://localhost:1080?ip=172.20.1.1:1080,172.20.1.2:1081 -- \
     -L socks5://localhost:1080                                             -- \
     -L :2020 -F kcp://10.16.1.10:8388?peer=peer1.txt                          \
              -F http2://12.20.1.3:443?peer=peer2.txt
```

Of course, some things could be improved as I didn't alter the main logic of gost which relies on the globals [gost.DefaultTLSConfig](https://github.com/ginuerzh/gost/commit/12a7b6f66bb2b634a2147c2c90c6de59d2b49045#diff-9d871a5f27180c9d9f5a24ece9b80b02b3decd835ee0d8bc5109cdabbf42c2a2R178), [gost.Debug](https://github.com/ginuerzh/gost/commit/12a7b6f66bb2b634a2147c2c90c6de59d2b49045#diff-9d871a5f27180c9d9f5a24ece9b80b02b3decd835ee0d8bc5109cdabbf42c2a2R105), and [gost.SetLogger()](https://github.com/ginuerzh/gost/commit/12a7b6f66bb2b634a2147c2c90c6de59d2b49045#diff-9d871a5f27180c9d9f5a24ece9b80b02b3decd835ee0d8bc5109cdabbf42c2a2R25). Among them, `gost.DefaultTLSConfig` is the most "damaging" one as it means that all the gost instances spawned with `--` will use the same TLS certificate (which won't happen if multiple gost processes are separately run in different terminals/processes instead of using `--`).

For sure, there are several ways of isolating `gost.DefaultTLSConfig` (and the other globals) per instance, but changes outside the scope of this simple PR are needed and, for my usage purposes, a shared TLS cert (or global debug/log) is perfectly fine 🕺

Finally, the [README.md](https://github.com/ginuerzh/gost/blob/b9a965f4c1220bb20f13222fbc5fe9ec0b7fb46a/README.md) will need to be updated to include my [README_en.md](https://github.com/ginuerzh/gost/commit/19af453e9c6b820260935b2427c0cc56cf542ec2) changes as I don't understand Chinese, unfortunately 😅