### PR TITLE
Add -M option for Fwmark

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -162,9 +162,9 @@ func (c *Chain) dialWithOptions(ctx context.Context, network, address string, op
 			return cc.Control(func(fd uintptr) {
 				ex := setSocketMark(int(fd), c.Mark)
 				if ex != nil {
-					log.Logf("net dialer set mark %d error: %s", options.Mark, ex)
+					log.Logf("net dialer set mark %d error: %s", c.Mark, ex)
 				} else {
-					log.Logf("net dialer set mark %d success", options.Mark)
+					// log.Logf("net dialer set mark %d success", options.Mark)
 				}
 			})
 		}

--- a/cmd/gost/main.go
+++ b/cmd/gost/main.go
@@ -31,6 +31,7 @@ func init() {
 
 	flag.Var(&baseCfg.route.ChainNodes, "F", "forward address, can make a forward chain")
 	flag.Var(&baseCfg.route.ServeNodes, "L", "listen address, can listen on multiple ports (required)")
+	flag.IntVar(&baseCfg.route.Mark, "M", 0, "Specify out connection mark")
 	flag.StringVar(&configureFile, "C", "", "configure file")
 	flag.BoolVar(&baseCfg.Debug, "D", false, "enable debug log")
 	flag.BoolVar(&printVersion, "V", false, "print version")

--- a/cmd/gost/route.go
+++ b/cmd/gost/route.go
@@ -30,11 +30,13 @@ type route struct {
 	ServeNodes stringList
 	ChainNodes stringList
 	Retries    int
+	Mark       int
 }
 
 func (r *route) parseChain() (*gost.Chain, error) {
 	chain := gost.NewChain()
 	chain.Retries = r.Retries
+	chain.Mark = r.Mark
 	gid := 1 // group ID
 
 	for _, ns := range r.ChainNodes {

--- a/handler.go
+++ b/handler.go
@@ -42,7 +42,6 @@ type HandlerOptions struct {
 	IPs           []string
 	TCPMode       bool
 	IPRoutes      []IPRoute
-	Mark          int
 }
 
 // HandlerOption allows a common way to set handler options.

--- a/handler.go
+++ b/handler.go
@@ -42,6 +42,7 @@ type HandlerOptions struct {
 	IPs           []string
 	TCPMode       bool
 	IPRoutes      []IPRoute
+	Mark          int
 }
 
 // HandlerOption allows a common way to set handler options.


### PR DESCRIPTION
Added an `-M <mark>` option to specify fwmark for outbound connections. It can also be set by config file.
```json
{
    "Routes": [
        {
            "Retries": 3,
            "ServeNodes": [
                "quic://:443"
            ],
            "Mark": 1000
        }
    ]
}
```