### PR TITLE
ignore linux error: File exists while add same route twice

### DIFF
--- a/tuntap_linux.go
+++ b/tuntap_linux.go
@@ -1,8 +1,10 @@
 package gost
 
 import (
+	"errors"
 	"fmt"
 	"net"
+	"syscall"
 
 	"github.com/docker/libcontainer/netlink"
 	"github.com/go-log/log"
@@ -149,7 +151,7 @@ func addTunRoutes(ifName string, routes ...IPRoute) error {
 		}
 		cmd := fmt.Sprintf("ip route add %s dev %s", route.Dest.String(), ifName)
 		log.Logf("[tun] %s", cmd)
-		if err := netlink.AddRoute(route.Dest.String(), "", "", ifName); err != nil {
+		if err := netlink.AddRoute(route.Dest.String(), "", "", ifName); err != nil && !errors.Is(err, syscall.EEXIST) {
 			return fmt.Errorf("%s: %v", cmd, err)
 		}
 	}


### PR DESCRIPTION
```shell
naison@naison-virtual-machine:~$ sudo ip route add 10.10.0.0/16 dev tun0
[sudo] password for naison: 
naison@naison-virtual-machine:~$ sudo ip route add 10.10.0.0/16 dev tun0
RTNETLINK answers: File exists
naison@naison-virtual-machine:~$ 
```
Linux如果重复添加相同路由，会报错已经存在，window和macOS不会报这样的错误。因此这里加上忽略已经存在的路由。
```shell
2021/08/21 11:19:21 tuntap_linux.go:40: [tun] ip link set dev tun0 mtu 1350
2021/08/21 11:19:21 tuntap_linux.go:47: [tun] ip address add 223.254.254.2/24 dev tun0
2021/08/21 11:19:21 tuntap_linux.go:54: [tun] ip link set dev tun0 up
2021/08/21 11:19:21 tuntap_linux.go:151: [tun] ip route add 10.10.0.0/16 dev tun0
2021/08/21 11:19:21 main.go:88: ip route add 10.10.0.0/16 dev tun0: file exists
```