### PR TITLE
允许绑定出口到指定网卡上

### DIFF
--- a/cmd/gost/main.go
+++ b/cmd/gost/main.go
@@ -33,6 +33,7 @@ func init() {
 	flag.Var(&baseCfg.route.ServeNodes, "L", "listen address, can listen on multiple ports (required)")
 	flag.IntVar(&baseCfg.route.Mark, "M", 0, "Specify out connection mark")
 	flag.StringVar(&configureFile, "C", "", "configure file")
+	flag.StringVar(&baseCfg.route.Interface, "I", "", "Interface to bind")
 	flag.BoolVar(&baseCfg.Debug, "D", false, "enable debug log")
 	flag.BoolVar(&printVersion, "V", false, "print version")
 	if pprofEnabled {

--- a/cmd/gost/route.go
+++ b/cmd/gost/route.go
@@ -31,12 +31,14 @@ type route struct {
 	ChainNodes stringList
 	Retries    int
 	Mark       int
+	Interface  string
 }
 
 func (r *route) parseChain() (*gost.Chain, error) {
 	chain := gost.NewChain()
 	chain.Retries = r.Retries
 	chain.Mark = r.Mark
+	chain.Interface = r.Interface
 	gid := 1 // group ID
 
 	for _, ns := range r.ChainNodes {

--- a/sockopts_linux.go
+++ b/sockopts_linux.go
@@ -5,3 +5,7 @@ import "syscall"
 func setSocketMark(fd int, value int) (e error) {
 	return syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_MARK, value)
 }
+
+func setSocketInterface(fd int, value string) (e error) {
+	return syscall.SetsockoptString(fd, syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, value)
+}

--- a/sockopts_other.go
+++ b/sockopts_other.go
@@ -5,3 +5,7 @@ package gost
 func setSocketMark(fd int, value int) (e error) {
 	return nil
 }
+
+func setSocketInterface(fd int, value string) (e error) {
+	return nil
+}


### PR DESCRIPTION
允许绑定到指定的网卡（使用 `SO_BINDTODEVICE`）

修复了 `newRoute` 会创建一个新 `Chain` 导致 `Mark` 设定在出口的时候被忽略