### PR TITLE
Compatible with older Go version

### DIFF
--- a/sockopts_other.go
+++ b/sockopts_other.go
@@ -1,4 +1,5 @@
 //go:build !linux
+// +build !linux
 
 package gost
 


### PR DESCRIPTION
To compatible with older Go version on some cloud environment , such as Google App Engine using 1.16