### PR TITLE
Wait for the second copy error

### DIFF
--- a/server.go
+++ b/server.go
@@ -103,7 +103,7 @@ type Listener interface {
 }
 
 func transport(rw1, rw2 io.ReadWriter) error {
-	errc := make(chan error, 1)
+	errc := make(chan error, 2)
 	go func() {
 		errc <- copyBuffer(rw1, rw2)
 	}()
@@ -113,10 +113,17 @@ func transport(rw1, rw2 io.ReadWriter) error {
 	}()
 
 	err := <-errc
+	err2 := <-errc
 	if err != nil && err == io.EOF {
 		err = nil
 	}
-	return err
+	if err != nil {
+		return err
+	}
+	if err2 != nil && err2 == io.EOF {
+		err2 = nil
+	}
+	return err2
 }
 
 func copyBuffer(dst io.Writer, src io.Reader) error {


### PR DESCRIPTION
If the method returns before the second direction is done, the socket may be closed or the error ignored. Typically not a problem, in most cases when a direction is closed the other is also done, but for some protocols it may matter, and it seems 
the correct way to handle. 