### PR TITLE
fix: close pipe after transport in socks bind

### DIFF
--- a/socks.go
+++ b/socks.go
@@ -1102,6 +1102,7 @@ func (h *socks5Handler) bindOn(conn net.Conn, addr string) {
 				log.Logf("[socks5-bind] %s - %s : %v", conn.RemoteAddr(), pconn.RemoteAddr(), err)
 			}
 			log.Logf("[socks5-bind] %s >-< %s", conn.RemoteAddr(), pconn.RemoteAddr())
+			pc2.Close()
 			return
 		case err := <-pipe():
 			if err != nil {


### PR DESCRIPTION
大致逻辑：
在 bind 连接成功建立之后
client <-> (gost: pc1 <-> pc2) <-> server

`client <-> pc1` 和 `pc2 <-> server` 直接的 <-> 均为双向 io.Copy

当  `pc2 <-> server` 连接断开，pc2 需要手动关闭。否则若 `client <-> pc1` 在极低速网络中，这两者之间的双向 io.Copy 有较大可能处在 `pc1.Write()` 和 `pc1.Read()`，此时  `pc2 <-> server`  连接断开，pc2 未被 close，pc1 的 write 和 read 将永远 hang 住。