### PR TITLE
use outgoing interface's IP for UDP relay port

### DIFF
--- a/socks.go
+++ b/socks.go
@@ -1125,7 +1125,7 @@ func (h *socks5Handler) handleUDPRelay(conn net.Conn, req *gosocks5.Request) {
 		return
 	}
 
-	relay, err := net.ListenUDP("udp", nil)
+	relay, err := net.ListenUDP("udp", &net.UDPAddr{IP: conn.LocalAddr().(*net.TCPAddr).IP, Port: 0}) // use out-going interface's IP
 	if err != nil {
 		log.Logf("[socks5-udp] %s -> %s : %s", conn.RemoteAddr(), conn.LocalAddr(), err)
 		reply := gosocks5.NewReply(gosocks5.Failure, nil)
@@ -1138,7 +1138,6 @@ func (h *socks5Handler) handleUDPRelay(conn net.Conn, req *gosocks5.Request) {
 	defer relay.Close()
 
 	socksAddr := toSocksAddr(relay.LocalAddr())
-	socksAddr.Host, _, _ = net.SplitHostPort(conn.LocalAddr().String()) // replace the IP to the out-going interface's
 	reply := gosocks5.NewReply(gosocks5.Succeeded, socksAddr)
 	if err := reply.Write(conn); err != nil {
 		log.Logf("[socks5-udp] %s <- %s : %s", conn.RemoteAddr(), conn.LocalAddr(), err)


### PR DESCRIPTION
(resending without an unnecessary file; cf. https://github.com/ginuerzh/gost/pull/1029)
Currently relay ports for SOCKS UDP associate are obtained with `nil` (`[::]:0`), and then replied to clients with the IP replaced by TCP local address.
My implementation uses the TCP local address instead of `nil` when getting UDP relay ports.
This solves possible problems in situations where the SOCKS server can be seen through more than one IP addresses.
For example, if we use some external interface address (like 10.0.0.1) to access gost SOCKS5 proxy running on the same machine as client, only my implementation will work, because current implementation will send back UDP packets using localhost (127.0.0.1), which is different from the replied relay port. 
Also, the current implementation typically replies IPv4-mapped IPv6 address to IPv4 clients (like ::ffff:10.0.0.1), which is incompatible with redsocks (https://github.com/semigodking/redsocks) which is one of the most widely-used transparent SOCKS5 proxy clients. My implementation will also fix this.